### PR TITLE
[ERM-13] Revert changes upon unsuccessfull rollout

### DIFF
--- a/core/src/test/java/com/exadel/etoolbox/rolloutmanager/core/servlets/RolloutServletTest.java
+++ b/core/src/test/java/com/exadel/etoolbox/rolloutmanager/core/servlets/RolloutServletTest.java
@@ -73,7 +73,7 @@ class RolloutServletTest {
             "/content/we-retail/ch/ca-es-ch-livecopy/experience"
     );
 
-    private final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
+    private final AemContext context = new AemContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
 
     @Mock
     private RolloutManager rolloutManager;


### PR DESCRIPTION
## Description

When AEM attempts to make a rollout for pages that have an MSM conflict (e.g. a page with the same name exists in a livecopy) it tries to resolve this conflict by renaming one of the pages. sometimes this process fails, but rollout manager does not clean the uncommited changes. Usually it does not cause any problems, but if we use the same resource resolver to perform any other operations, the uncommited changes are then committed. 

## Related Issue

#24 